### PR TITLE
fix(nav): fix active & optimize code

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -27,7 +27,7 @@
 
           <!-- 指南 / 组件 -->
           <div class="nav-item" v-for="item in header" :key="item.name">
-            <template v-if="docMd === 'react' && item.name === 'Components'">
+            <template v-if="docMd === 'react' && item.name === 'Component'">
               <a class="transition-colors hover:text-gray-700 dark:hover:text-gray-400"
                 :class="isActive(item.name) ? 'text-gray-400 dark:text-gray-400 111' : 'text-gray-500 dark:text-gray-500'"
                 :href="`${ isZhLang ? `${item.pathName}-react` : `${item.pathEnName}-react`}`">
@@ -96,7 +96,7 @@
     },
     setup() {
       const version = ref()
-      const isZhLang = localStorage.getItem("language") === "zh-CN" ? true : false;
+      const isZhLang = localStorage.getItem("language") === "zh-CN";
       const route = useRoute();
       let packages = [];
       nav.forEach((item) => {
@@ -131,13 +131,7 @@
       const isActive = computed(() => {
         return function (name: string) {
           const lName = name.toLowerCase();
-          if (lName === "components") {
-            return route.path.includes("component");
-          } else if (lName === 'pages') {
-            return route.path.includes("pages");
-          } else {
-            return route.path.includes("guide");
-          }
+          return route.path.includes(lName)
         };
       });
 

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -150,7 +150,7 @@ export default defineComponent({
     });
 
     const getIsGuaid = (path: string) => {
-      state.isGuideNav = path.indexOf("guide") > -1 ? true : false;
+      state.isGuideNav = path.indexOf("guide") > -1;
     };
 
     onBeforeRouteUpdate((to: any) => {
@@ -160,7 +160,7 @@ export default defineComponent({
     return {
       ...toRefs(data),
       ...toRefs(state),
-      isZhLang: localStorage.getItem("language") === "zh-CN" ? true : false,
+      isZhLang: localStorage.getItem("language") === "zh-CN",
       isActive,
       docMd: localStorage.getItem("docMd"),
       nav: reactive(nav),

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -60,7 +60,7 @@ export default defineComponent({
 
       // command + k 快捷键
       document.onkeydown = function(event){
-				if(event.metaKey && event.keyCode == 75){
+				if(event.metaKey && event.keyCode === 75){
           // console.log(refInput, 111);
           nextTick(() => {
             refInput.value.focus();
@@ -111,10 +111,10 @@ export default defineComponent({
 
     const choseList = (e) => {
       let searchIndex = data.searchIndex;
-      if (e.keyCode == 40) {
+      if (e.keyCode === 40) {
         searchIndex++;
       }
-      if (e.keyCode == 38) {
+      if (e.keyCode === 38) {
         searchIndex--;
       }
       if (searchIndex < 0) {
@@ -126,7 +126,7 @@ export default defineComponent({
         if (cName) {
           data.searchCurName = cName;
           data.searchIndex = searchIndex;
-          if (e.keyCode == 13) {
+          if (e.keyCode === 13) {
             router.push({
               path: `/${localStorage.getItem("language")}/component/${
                 searchList[searchIndex].name
@@ -146,7 +146,7 @@ export default defineComponent({
       choseList,
       onblur,
       checklist,
-      isZhLang: localStorage.getItem("language") === "zh-CN" ? true : false,
+      isZhLang: localStorage.getItem("language") === "zh-CN",
       refInput,
       quickSearch,
     };

--- a/src/config/baseConfig.ts
+++ b/src/config/baseConfig.ts
@@ -9,7 +9,7 @@ export default {
       pathEnName: "#/en-US/guide/introduction", // TODO: 临时方案
     },
     {
-      name: "Components",
+      name: "Component",
       cName: "组件",
       path: "#/component/button",
       pathName: "#/zh-CN/component/button",

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -39,7 +39,7 @@ export default defineComponent({
   },
   setup() {
     const isZhLang =
-      localStorage.getItem("language") === "zh-CN" ? true : false;
+      localStorage.getItem("language") === "zh-CN";
     const docMd = localStorage.getItem("docMd");
     const route = useRoute();
     // const router = useRouter();

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, onMounted, reactive, toRefs, ref } from "vue";
+  import { defineComponent, onMounted } from "vue";
   import { useI18n } from "vue-i18n";
   import Header from "@/components/Header.vue";
   import ComponentsOverview from "./components/overview/index.vue";
@@ -52,7 +52,7 @@
       });
 
       return {
-        isZhLang: localStorage.getItem("language") === "zh-CN" ? true : false,
+        isZhLang: localStorage.getItem("language") === "zh-CN",
         t,
       };
     },

--- a/src/views/components/overview/index.vue
+++ b/src/views/components/overview/index.vue
@@ -511,7 +511,7 @@
 
       const docMd = localStorage.getItem("docMd");
       
-      const isZhLang = localStorage.getItem("language") === "zh-CN" ? true : false;
+      const isZhLang = localStorage.getItem("language") === "zh-CN";
       
       return { 
         t,


### PR DESCRIPTION
现在的bug是nav的active在组件那边没有响应哦， 灰色的
![image](https://user-images.githubusercontent.com/117748716/202852866-6c5ba249-ede3-4e07-86cd-76b22743cd2b.png)

1. 这么修改可能又把这个代码改回去了，但是不会出bug https://github.com/hellof2e/quark-design-docs/pull/10
因为感觉这种似乎一样的代码没什么太大意义，不如改掉header的name好了，现在fix的active是因为 baseconfig里面的name: "Components", 而并不是这里面if条件设置的component，感觉改来改去，不如直接和路由的component统一好了
![image](https://user-images.githubusercontent.com/117748716/202852217-d4bb2e50-199e-44f8-bf92-e1cd1b1a4d70.png)
2. === "zh-CN" ? true : false 这种似乎重复了，返回的已经是boolean了
3.  == -> === & remove useless