### PR TITLE
Doc: 修复使用示例 Html 的 JS 位置，确保可以正确执行

### DIFF
--- a/src/views/components/codedemo/index.vue
+++ b/src/views/components/codedemo/index.vue
@@ -71,15 +71,15 @@ import "quarkd/lib/button"
     <meta charset="utf-8">
   </head>
   <script src="https://fastly.jsdelivr.net/npm/quarkd@1.0.11/umd/index.js" />
+  <body>
+    <quark-button loading="false" id="btn">Button</quark-button>
+  </body>
   <script>
     const el = document.getElementById('btn')
     el.addEventListener('click', function handleClick() {
       el.loading = true
     })
-<\/script>
-<body>
-  <quark-button loading="false" id="btn">Button</quark-button>
-</body>
+  <\/script>
 </html>
   `,
 };


### PR DESCRIPTION
之前 `const el = document.getElementById('btn')` 位置在 <body> 上面，导致得到的 el 值为 null，需要将这段 JS 放到 body 下面，以确保执行该 JS 时已创建了 `<quark-button>`。 
就好像这个示例文档中的那样：
https://github.com/hellof2e/quark-design-docs/blob/main/src/docs/quickstart.zh-CN.md#%E6%97%A0%E6%A1%86%E6%9E%B6jquery%E7%AD%89